### PR TITLE
Add support for setting and getting the originator of an event

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -30,6 +30,12 @@ namespace Symfony\Component\EventDispatcher;
 class Event
 {
     /**
+     * @var array The object that originated the event
+     * Keys are 'object', 'file', and 'line'
+     */
+    private $originatorData;
+
+    /**
      * @var Boolean Whether no further event listeners should be triggered
      */
     private $propagationStopped = false;
@@ -43,6 +49,24 @@ class Event
      * @var string This event's name
      */
     private $name;
+
+    /**
+     * @param array $originatorData The object that originated the event
+     * Keys are 'object', 'file', and 'line'
+     */
+    public function setOriginatorData($originatorData)
+    {
+        $this->originatorData = $originatorData;
+    }
+
+    /**
+     * @return array The object that originated the event
+     * Keys are 'object', 'file', and 'line'
+     */
+    public function getOriginatorData()
+    {
+        return $this->originatorData;
+    }
 
     /**
      * Returns whether further event listeners should be triggered.

--- a/EventDispatcher.php
+++ b/EventDispatcher.php
@@ -45,6 +45,7 @@ class EventDispatcher implements EventDispatcherInterface
 
         $event->setDispatcher($this);
         $event->setName($eventName);
+        $event->setOriginatorData($this->getOriginatorData());
 
         if (!isset($this->listeners[$eventName])) {
             return $event;
@@ -54,6 +55,28 @@ class EventDispatcher implements EventDispatcherInterface
 
         return $event;
     }
+
+	protected function getOriginatorData()
+	{
+        $backtrace = debug_backtrace();
+
+        if (isset($backtrace[2]['object']))
+        {
+            return array(
+                'object' => $backtrace[2]['object'],
+                'file' => $backtrace[1]['file'],
+                'line' => $backtrace[1]['line']
+            );
+        }
+        else
+        {
+            return array(
+                'object' => $backtrace[1]['object'],
+                'file' => $backtrace[1]['file'],
+                'line' => $backtrace[1]['line']
+            );
+        }
+	}
 
     /**
      * @see EventDispatcherInterface::getListeners


### PR DESCRIPTION
The "originator" is the object and/or file and line number of the code that
called `EventDispatcher::dispatch`

This could be useful for debugging although my original motivation for
this is that in my project I want the listener to be able to find out
about objects that it otherwise wouldn't know about, because the objects
are created after the listener is attached.

In my specific example, I am creating for our proprietary MVC framework a debug toolbar much like Symfony's and I need a listener that is called when a view is rendered and I need that listener to be able to find out the view object that dispatched the event. This allows me to do that without subclassing `Event`.
