### PR TITLE
Update EventSubscriberInterface.php

### DIFF
--- a/EventSubscriberInterface.php
+++ b/EventSubscriberInterface.php
@@ -42,5 +42,5 @@ interface EventSubscriberInterface
      *
      * @return array The event names to listen to
      */
-    public static function getSubscribedEvents();
+    public function getSubscribedEvents();
 }


### PR DESCRIPTION
EventSubscriberInterface::getSubscribedEvents should not be static - every call to this method seems to be instance-based.

Problem:
Development of a "dynamic registration"-Subscriber based on Constructor-Params impossible.

Solution:
Change call-type of getSubscribedEvents to instance.

Side-Effects:
None known - all calls are instance-calls.