### PR TITLE
Add missing doc blocks to the EventDispatcherInterface interface

### DIFF
--- a/EventDispatcherInterface.php
+++ b/EventDispatcherInterface.php
@@ -51,6 +51,13 @@ interface EventDispatcherInterface extends ContractsEventDispatcherInterface
      */
     public function removeListener(string $eventName, $listener);
 
+    /**
+     * Removes an event subscriber
+     *
+     * @param EventSubscriberInterface $subscriber
+     *
+     * @return void
+     */
     public function removeSubscriber(EventSubscriberInterface $subscriber);
 
     /**


### PR DESCRIPTION
Add missing doc blocks to the EventDispatcherInterface interface.

Necessary since the subclasses which are using this contract are using the `* {@inheritdoc}` tag.