### PR TITLE
correct the event listener method case

### DIFF
--- a/DependencyInjection/RegisterListenersPass.php
+++ b/DependencyInjection/RegisterListenersPass.php
@@ -102,7 +102,7 @@ class RegisterListenersPass implements CompilerPassInterface
 
                 if (!isset($event['method'])) {
                     $event['method'] = 'on'.preg_replace_callback([
-                        '/(?<=\b)[a-z]/i',
+                        '/(?<=[\b\._])[a-z]/i',
                         '/[^a-z0-9]/i',
                     ], function ($matches) { return strtoupper($matches[0]); }, $event['event']);
                     $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);


### PR DESCRIPTION
Hi, 
Today I found that the actual method's case of event listener was wrong, when no method was specified, for example, event name: `kernel.controller_arguments`, expected default method name: `onkernelControllerArguments`, actual method called: `onKernelControllerarguments`, but actually it's ok,  php is case-insenstive for function call.

ps, a service.yaml example:

```yaml
services:
  my_kernel_envent_listeners:
        class: App\EventListener\KernelListener
        tags:
            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
            - { name: kernel.event_listener, event: kernel.controller_arguments } # no `method` at this tag
```