### PR TITLE
Fixes deprecation: return type declaration

### DIFF
--- a/EventSubscriberInterface.php
+++ b/EventSubscriberInterface.php
@@ -45,5 +45,5 @@ interface EventSubscriberInterface
      *
      * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
      */
-    public static function getSubscribedEvents();
+    public static function getSubscribedEvents(): array;
 }


### PR DESCRIPTION
getSubscribedEvents() might add "array" as a native return type declaration