### PR TITLE
Make EventDispatcher more extensible.

### DIFF
--- a/EventDispatcher.php
+++ b/EventDispatcher.php
@@ -55,9 +55,7 @@ class EventDispatcher implements EventDispatcherInterface
             $listeners = $this->getListeners($eventName);
         }
 
-        if ($listeners) {
-            $this->callListeners($listeners, $eventName, $event);
-        }
+        $this->callListeners($listeners, $eventName, $event);
 
         return $event;
     }


### PR DESCRIPTION
By removing the check if $listeners has any listeners, we could reliably extend the protected callListeners().
This would open the door for implementing the PSR-14 Psr\EventDispatcher\ListenerProviderInterface.